### PR TITLE
Deploy all 4 Cloudflare Workers with provisioned resources

### DIFF
--- a/edge/fire-ai/wrangler.toml
+++ b/edge/fire-ai/wrangler.toml
@@ -68,7 +68,7 @@ index_name = "civic-embeddings"
 
 [[kv_namespaces]]
 binding = "AI_CACHE"
-id = "REPLACE_WITH_KV_NAMESPACE_ID"    # Create via: npx wrangler kv namespace create AI_CACHE
+id = "8e4ceb074a124eec9c2537d425cf8523"
 
 # -----------------------------------------------------------------------------
 # AI Gateway (optional, recommended for production)

--- a/edge/fire-api/wrangler.toml
+++ b/edge/fire-api/wrangler.toml
@@ -32,12 +32,12 @@ compatibility_date = "2026-02-24"
 
 [[kv_namespaces]]
 binding = "CACHE"
-id = "REPLACE_WITH_KV_NAMESPACE_ID"       # Create via: npx wrangler kv namespace create CACHE
+id = "d251283c91604bfd871189fcc92ec06f"
 # preview_id = "REPLACE_FOR_DEV"          # Create via: npx wrangler kv namespace create CACHE --preview
 
 [[kv_namespaces]]
 binding = "CONFIG"
-id = "REPLACE_WITH_KV_NAMESPACE_ID"       # Create via: npx wrangler kv namespace create CONFIG
+id = "ba41b41155b7461cb8f47e20905d6880"
 
 # -----------------------------------------------------------------------------
 # D1 Database
@@ -53,7 +53,7 @@ id = "REPLACE_WITH_KV_NAMESPACE_ID"       # Create via: npx wrangler kv namespac
 [[d1_databases]]
 binding = "CIVIC_DB"
 database_name = "civic-data"
-database_id = "REPLACE_WITH_D1_DATABASE_ID"   # Create via: npx wrangler d1 create civic-data
+database_id = "b7eb088d-67a8-42cf-b79c-ef58419b21e0"
 
 # -----------------------------------------------------------------------------
 # R2 Bucket

--- a/edge/fire-relay/wrangler.toml
+++ b/edge/fire-relay/wrangler.toml
@@ -26,7 +26,7 @@ compatibility_date = "2026-02-24"
 
 [[kv_namespaces]]
 binding = "NODES"
-id = "REPLACE_WITH_KV_NAMESPACE_ID"       # Create via: npx wrangler kv namespace create NODES
+id = "4d3fc279403b4c8c8222a11d0ca63008"
 
 # -----------------------------------------------------------------------------
 # KV Namespace — Relay Configuration
@@ -36,7 +36,7 @@ id = "REPLACE_WITH_KV_NAMESPACE_ID"       # Create via: npx wrangler kv namespac
 
 [[kv_namespaces]]
 binding = "CONFIG"
-id = "REPLACE_WITH_KV_NAMESPACE_ID"       # Create via: npx wrangler kv namespace create RELAY_CONFIG
+id = "a4417a9f84df4cc0904ab0ff950b9ff6"
 
 # -----------------------------------------------------------------------------
 # D1 Database — Federation Log
@@ -48,7 +48,7 @@ id = "REPLACE_WITH_KV_NAMESPACE_ID"       # Create via: npx wrangler kv namespac
 [[d1_databases]]
 binding = "RELAY_DB"
 database_name = "fire-relay"
-database_id = "REPLACE_WITH_D1_DATABASE_ID"   # Create via: npx wrangler d1 create fire-relay
+database_id = "a032bc72-1bab-41c8-a9b7-52492124ca02"
 
 # -----------------------------------------------------------------------------
 # Service Binding to fire-ai for optional AI verification


### PR DESCRIPTION
## Summary

Closes #146

Deploy the complete Cleansing Fire edge infrastructure. All 4 workers are now live:

| Worker | URL | Bindings |
|--------|-----|----------|
| fire-markdown | [fire-markdown.brian-mabry-edwards.workers.dev](https://fire-markdown.brian-mabry-edwards.workers.dev/health) | env var only |
| fire-ai | [fire-ai.brian-mabry-edwards.workers.dev](https://fire-ai.brian-mabry-edwards.workers.dev/health) | KV, Vectorize, Workers AI |
| fire-relay | [fire-relay.brian-mabry-edwards.workers.dev](https://fire-relay.brian-mabry-edwards.workers.dev/) | KV×2, D1, service binding |
| fire-api | [fire-api.brian-mabry-edwards.workers.dev](https://fire-api.brian-mabry-edwards.workers.dev/health) | KV×2, D1, R2, Queue, service binding |

## Changes

Updated `wrangler.toml` files to replace placeholder IDs with real provisioned Cloudflare resource IDs. These are infrastructure identifiers, not secrets.

## Resources Provisioned

- 5 KV namespaces: NODES, RELAY_CONFIG, AI_CACHE, CACHE, CONFIG
- 2 D1 databases: fire-relay (with schema applied), civic-data
- 1 R2 bucket: fire-media
- 1 Queue: fire-task-queue
- 1 Vectorize index: civic-embeddings (1024 dimensions, cosine metric)

## Verification

All 4 workers respond to health checks. No secrets committed.