### PR TITLE
specs: add plugin-registry, deployment-spec, and data-model specs

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -68,8 +68,11 @@ Specs should be validatable:
 |------|--------|---------|
 | `project-graph.yaml` | YAML | Component dependency graph -- what exists and how it connects |
 | `plugin-schema.json` | JSON Schema | Formal definition of the plugin interface contract |
+| `plugin-registry.yaml` | YAML | Catalog of all plugins with actions, dependencies, and API requirements |
 | `agent-capabilities.yaml` | YAML | What AI agents can do, their tools, and their boundaries |
 | `goals.yaml` | YAML | Project goal hierarchy with success criteria and priorities |
+| `deployment-spec.yaml` | YAML | Deployment targets, configurations, and infrastructure bindings |
+| `data-model.yaml` | YAML | D1 database schema -- tables, columns, types, constraints |
 
 ## Relationship to CLAUDE.md
 

--- a/specs/data-model.yaml
+++ b/specs/data-model.yaml
@@ -1,0 +1,422 @@
+# =============================================================================
+# Data Model — Cleansing Fire
+# =============================================================================
+# D1 database schema specification for civic data storage.
+# Defines all tables, columns, types, constraints, and relationships.
+#
+# For humans: see docs/global-architecture.md (section on D1)
+# For agents: use this file for query construction and data insertion
+# =============================================================================
+
+metadata:
+  version: "0.1.0"
+  updated: "2026-02-28"
+  description: "D1 database schema for civic-data and fire-relay databases"
+  human_docs:
+    - path: "docs/global-architecture.md"
+      description: "Planetary-scale architecture including data layer"
+    - path: "docs/cloudflare-implementation.md"
+      description: "Cloudflare implementation with D1 details"
+
+# =============================================================================
+# Database: civic-data (bound as CIVIC_DB in fire-api)
+# =============================================================================
+
+databases:
+
+  civic-data:
+    binding: CIVIC_DB
+    worker: fire-api
+    description: "Primary structured data store for civic intelligence"
+
+    tables:
+
+      # -----------------------------------------------------------------------
+      # Core entities — people, organizations, and their relationships
+      # -----------------------------------------------------------------------
+
+      entities:
+        description: "People, companies, agencies, PACs, and other entities under investigation"
+        columns:
+          id:
+            type: TEXT
+            primary_key: true
+            description: "UUID v4"
+          name:
+            type: TEXT
+            not_null: true
+            description: "Primary name of the entity"
+          type:
+            type: TEXT
+            not_null: true
+            description: "Entity type"
+            check: "type IN ('person', 'company', 'agency', 'pac', 'nonprofit', 'lobbyist', 'media', 'other')"
+          aliases:
+            type: TEXT
+            description: "JSON array of alternate names, previous names"
+          description:
+            type: TEXT
+            description: "Brief description"
+          source:
+            type: TEXT
+            description: "Where this entity was first identified"
+          confidence:
+            type: REAL
+            default: 0.5
+            description: "Confidence score 0.0-1.0"
+            check: "confidence >= 0.0 AND confidence <= 1.0"
+          created_at:
+            type: TEXT
+            not_null: true
+            default: "CURRENT_TIMESTAMP"
+          updated_at:
+            type: TEXT
+            not_null: true
+            default: "CURRENT_TIMESTAMP"
+        indexes:
+          - name: idx_entities_type
+            columns: [type]
+          - name: idx_entities_name
+            columns: [name]
+
+      # -----------------------------------------------------------------------
+      relationships:
+        description: "Connections between entities — ownership, donation, employment, lobbying"
+        columns:
+          id:
+            type: TEXT
+            primary_key: true
+          source_entity_id:
+            type: TEXT
+            not_null: true
+            foreign_key: "entities(id)"
+          target_entity_id:
+            type: TEXT
+            not_null: true
+            foreign_key: "entities(id)"
+          type:
+            type: TEXT
+            not_null: true
+            description: "Relationship type"
+            check: "type IN ('owns', 'subsidiary_of', 'donates_to', 'employs', 'lobbies_for', 'contracts_with', 'board_member', 'revolving_door', 'related_to', 'other')"
+          amount:
+            type: REAL
+            description: "Dollar amount if applicable (donations, contracts)"
+          period:
+            type: TEXT
+            description: "Time period (e.g., '2024', '2023-Q3')"
+          source:
+            type: TEXT
+            description: "Data source (e.g., 'FEC', 'SEC', 'OpenSecrets')"
+          confidence:
+            type: REAL
+            default: 0.5
+          metadata:
+            type: TEXT
+            description: "JSON blob with source-specific details"
+          created_at:
+            type: TEXT
+            not_null: true
+            default: "CURRENT_TIMESTAMP"
+        indexes:
+          - name: idx_rel_source
+            columns: [source_entity_id]
+          - name: idx_rel_target
+            columns: [target_entity_id]
+          - name: idx_rel_type
+            columns: [type]
+
+      # -----------------------------------------------------------------------
+      # Investigation tracking
+      # -----------------------------------------------------------------------
+
+      investigations:
+        description: "Active investigation threads"
+        columns:
+          id:
+            type: TEXT
+            primary_key: true
+          title:
+            type: TEXT
+            not_null: true
+          description:
+            type: TEXT
+          status:
+            type: TEXT
+            not_null: true
+            default: "'active'"
+            check: "status IN ('active', 'paused', 'completed', 'archived')"
+          priority:
+            type: INTEGER
+            default: 5
+            check: "priority >= 1 AND priority <= 10"
+          entity_ids:
+            type: TEXT
+            description: "JSON array of related entity IDs"
+          findings:
+            type: TEXT
+            description: "JSON array of findings"
+          created_at:
+            type: TEXT
+            not_null: true
+            default: "CURRENT_TIMESTAMP"
+          updated_at:
+            type: TEXT
+            not_null: true
+            default: "CURRENT_TIMESTAMP"
+        indexes:
+          - name: idx_inv_status
+            columns: [status]
+
+      # -----------------------------------------------------------------------
+      # Document and evidence storage (metadata — files in R2)
+      # -----------------------------------------------------------------------
+
+      documents:
+        description: "Document metadata — actual files stored in R2 MEDIA bucket"
+        columns:
+          id:
+            type: TEXT
+            primary_key: true
+          title:
+            type: TEXT
+            not_null: true
+          type:
+            type: TEXT
+            not_null: true
+            check: "type IN ('filing', 'foia_response', 'article', 'report', 'tip', 'attachment', 'generated', 'other')"
+          r2_key:
+            type: TEXT
+            description: "R2 object key for the actual file"
+          mime_type:
+            type: TEXT
+          size_bytes:
+            type: INTEGER
+          source_url:
+            type: TEXT
+          entity_ids:
+            type: TEXT
+            description: "JSON array of related entity IDs"
+          investigation_id:
+            type: TEXT
+            foreign_key: "investigations(id)"
+          summary:
+            type: TEXT
+            description: "AI-generated summary"
+          embedding_id:
+            type: TEXT
+            description: "Vectorize embedding ID for semantic search"
+          created_at:
+            type: TEXT
+            not_null: true
+            default: "CURRENT_TIMESTAMP"
+        indexes:
+          - name: idx_doc_type
+            columns: [type]
+          - name: idx_doc_investigation
+            columns: [investigation_id]
+
+      # -----------------------------------------------------------------------
+      # Tips and submissions
+      # -----------------------------------------------------------------------
+
+      tips:
+        description: "Anonymous tips and whistleblower submissions"
+        columns:
+          id:
+            type: TEXT
+            primary_key: true
+          tracking_id:
+            type: TEXT
+            not_null: true
+            unique: true
+            description: "Public tracking ID for tip status"
+          status:
+            type: TEXT
+            not_null: true
+            default: "'received'"
+            check: "status IN ('received', 'triaged', 'investigating', 'actionable', 'archived')"
+          urgency:
+            type: TEXT
+            default: "'normal'"
+            check: "urgency IN ('low', 'normal', 'high', 'critical')"
+          category:
+            type: TEXT
+          summary:
+            type: TEXT
+            description: "AI-classified summary (never contains raw tip text)"
+          investigation_id:
+            type: TEXT
+            foreign_key: "investigations(id)"
+          sender_hash:
+            type: TEXT
+            description: "SHA-256 hash of sender identity (privacy protection)"
+          received_at:
+            type: TEXT
+            not_null: true
+            default: "CURRENT_TIMESTAMP"
+          triaged_at:
+            type: TEXT
+        indexes:
+          - name: idx_tips_tracking
+            columns: [tracking_id]
+          - name: idx_tips_status
+            columns: [status]
+          - name: idx_tips_urgency
+            columns: [urgency]
+
+      # -----------------------------------------------------------------------
+      # FOIA tracking
+      # -----------------------------------------------------------------------
+
+      foia_requests:
+        description: "FOIA request tracking — filed, pending, received, appealed"
+        columns:
+          id:
+            type: TEXT
+            primary_key: true
+          agency:
+            type: TEXT
+            not_null: true
+          topic:
+            type: TEXT
+            not_null: true
+          status:
+            type: TEXT
+            not_null: true
+            default: "'drafted'"
+            check: "status IN ('drafted', 'filed', 'acknowledged', 'processing', 'partial_response', 'completed', 'denied', 'appealed')"
+          muckrock_id:
+            type: TEXT
+            description: "MuckRock request ID if filed through MuckRock"
+          filed_at:
+            type: TEXT
+          response_due:
+            type: TEXT
+          response_received:
+            type: TEXT
+          document_ids:
+            type: TEXT
+            description: "JSON array of document IDs for responses"
+          investigation_id:
+            type: TEXT
+            foreign_key: "investigations(id)"
+          created_at:
+            type: TEXT
+            not_null: true
+            default: "CURRENT_TIMESTAMP"
+        indexes:
+          - name: idx_foia_status
+            columns: [status]
+          - name: idx_foia_agency
+            columns: [agency]
+
+      # -----------------------------------------------------------------------
+      # Content tracking
+      # -----------------------------------------------------------------------
+
+      content:
+        description: "Generated and published content"
+        columns:
+          id:
+            type: TEXT
+            primary_key: true
+          type:
+            type: TEXT
+            not_null: true
+            check: "type IN ('post', 'thread', 'article', 'digest', 'satire', 'visualization', 'poem', 'legal_doc')"
+          title:
+            type: TEXT
+          body:
+            type: TEXT
+          investigation_id:
+            type: TEXT
+            foreign_key: "investigations(id)"
+          plugin:
+            type: TEXT
+            description: "Plugin that generated this content"
+          platform:
+            type: TEXT
+            description: "Target distribution platform"
+          published_url:
+            type: TEXT
+          published_at:
+            type: TEXT
+          created_at:
+            type: TEXT
+            not_null: true
+            default: "CURRENT_TIMESTAMP"
+        indexes:
+          - name: idx_content_type
+            columns: [type]
+          - name: idx_content_investigation
+            columns: [investigation_id]
+
+  # =============================================================================
+  # Database: fire-relay (bound as RELAY_DB in fire-relay)
+  # =============================================================================
+
+  fire-relay:
+    binding: RELAY_DB
+    worker: fire-relay
+    description: "Federation relay append-only event log"
+
+    tables:
+
+      relay_events:
+        description: "Append-only log of relay events for transparency"
+        columns:
+          id:
+            type: INTEGER
+            primary_key: true
+            autoincrement: true
+          event_type:
+            type: TEXT
+            not_null: true
+            check: "event_type IN ('register', 'deregister', 'heartbeat', 'relay', 'error')"
+          node_id:
+            type: TEXT
+          node_endpoint:
+            type: TEXT
+          source_ip_hash:
+            type: TEXT
+            description: "SHA-256 hash of source IP (privacy)"
+          payload_hash:
+            type: TEXT
+            description: "SHA-256 hash of event payload"
+          timestamp:
+            type: TEXT
+            not_null: true
+            default: "CURRENT_TIMESTAMP"
+        indexes:
+          - name: idx_relay_type
+            columns: [event_type]
+          - name: idx_relay_node
+            columns: [node_id]
+          - name: idx_relay_time
+            columns: [timestamp]
+
+      registered_nodes:
+        description: "Currently registered federation nodes"
+        columns:
+          node_id:
+            type: TEXT
+            primary_key: true
+          endpoint:
+            type: TEXT
+            not_null: true
+          capabilities:
+            type: TEXT
+            description: "JSON array of node capabilities"
+          version:
+            type: TEXT
+          last_seen:
+            type: TEXT
+            not_null: true
+          registered_at:
+            type: TEXT
+            not_null: true
+            default: "CURRENT_TIMESTAMP"
+        indexes:
+          - name: idx_nodes_last_seen
+            columns: [last_seen]

--- a/specs/deployment-spec.yaml
+++ b/specs/deployment-spec.yaml
@@ -1,0 +1,192 @@
+# =============================================================================
+# Deployment Specification — Cleansing Fire
+# =============================================================================
+# Machine-readable definition of all deployment targets, their configurations,
+# bindings, and relationships.
+#
+# For humans: see docs/cloudflare-implementation.md, docs/zero-touch-bootstrap.md
+# For agents: use this file to understand what's deployed where
+# =============================================================================
+
+metadata:
+  version: "0.1.0"
+  updated: "2026-02-28"
+  description: "Deployment targets, configurations, and infrastructure bindings"
+  human_docs:
+    - path: "docs/cloudflare-implementation.md"
+      description: "Full Cloudflare architecture and cost analysis"
+    - path: "docs/zero-touch-bootstrap.md"
+      description: "One-command node deployment"
+    - path: "docs/global-architecture.md"
+      description: "Planetary-scale deployment architecture"
+
+# =============================================================================
+# GitHub Pages — Static site
+# =============================================================================
+
+github_pages:
+  source:
+    branch: main
+    directory: "docs/"
+  url: "https://bedwards.github.io/cleansing-fire"
+  deployment:
+    trigger: push to main (automatic)
+    workflow: null  # GitHub Pages built-in
+  content:
+    - "docs/index.html"        # Split landing page (human + AI)
+    - "docs/humans.html"       # Human portal
+    - "docs/agents.html"       # AI agent portal
+    - "docs/*.md"              # Research documents (26+)
+
+# =============================================================================
+# Cloudflare Workers — Edge compute
+# =============================================================================
+
+cloudflare:
+  deployment:
+    workflow: ".github/workflows/deploy-workers.yml"
+    trigger: "push to main when edge/ changes"
+    tool: "wrangler"
+    node_version: "22"
+    required_secrets:
+      - CLOUDFLARE_API_TOKEN
+      - CLOUDFLARE_ACCOUNT_ID
+
+  # ---------------------------------------------------------------------------
+  workers:
+
+    fire-ai:
+      path: "edge/fire-ai/"
+      description: "Workers AI inference — analysis, embeddings, summarization, classification"
+      compatibility_date: "2026-02-24"
+      deploy_order: 1  # Must deploy before fire-api (service binding dependency)
+      bindings:
+        ai:
+          binding: AI
+          description: "Workers AI models"
+      models_used:
+        - "@cf/meta/llama-3.3-70b-instruct-fp8-fast"  # Deep analysis
+        - "@cf/google/gemma-3-12b-it"                   # Lightweight tasks
+        - "@cf/baai/bge-large-en-v1.5"                  # Embeddings
+
+    fire-api:
+      path: "edge/fire-api/"
+      description: "REST API gateway — investigations, queries, content management"
+      compatibility_date: "2026-02-24"
+      deploy_order: 2  # After fire-ai
+      bindings:
+        kv:
+          - binding: CACHE
+            namespace: "fire-cache"
+            description: "Response cache, content fragments, config"
+        d1:
+          - binding: CIVIC_DB
+            database: "civic-data"
+            description: "Structured civic data — entities, relationships, investigations"
+        r2:
+          - binding: MEDIA
+            bucket: "fire-media"
+            description: "Documents, images, PDFs, generated media"
+        services:
+          - binding: FIRE_AI
+            service: "fire-ai"
+            description: "Internal binding to AI worker (zero-latency)"
+        queues:
+          - binding: TASK_QUEUE
+            queue: "fire-task-queue"
+            description: "Async task dispatch"
+      endpoints:
+        - "GET  /health"
+        - "GET  /api/v1/investigations"
+        - "POST /api/v1/investigations"
+        - "GET  /api/v1/entities/:id"
+        - "GET  /api/v1/search"
+
+    fire-markdown:
+      path: "edge/fire-markdown/"
+      description: "LLM-accessible markdown proxy — content negotiation for AI agents"
+      compatibility_date: "2026-02-24"
+      deploy_order: 3  # Independent
+      bindings: {}  # Stateless proxy
+      vars:
+        ORIGIN: "https://bedwards.github.io/cleansing-fire"
+      conventions:
+        - "Accept: text/markdown header"
+        - "?format=md query parameter"
+        - "/llms.txt (llmstxt.org standard)"
+        - "/llms-full.txt (expanded)"
+
+    fire-relay:
+      path: "edge/fire-relay/"
+      description: "Federation bootstrap relay — node registration, peer discovery"
+      compatibility_date: "2026-02-24"
+      deploy_order: 3  # Independent
+      bindings:
+        kv:
+          - binding: NODES
+            namespace: "fire-relay-nodes"
+            description: "Node registry with TTL-based expiration"
+          - binding: CONFIG
+            namespace: "fire-relay-config"
+            description: "Relay configuration, rate limits, blocklists"
+        d1:
+          - binding: RELAY_DB
+            database: "fire-relay"
+            description: "Append-only federation event log"
+        services:
+          - binding: FIRE_AI
+            service: "fire-ai"
+            description: "AI verification of node registrations"
+
+# =============================================================================
+# Local Services — Per-node daemons
+# =============================================================================
+
+local_services:
+  gatekeeper:
+    path: "daemon/gatekeeper.py"
+    port: 7800
+    description: "HTTP server serializing GPU access to local Ollama"
+    queue_size: 5
+    default_model: "mistral-large:123b"
+    endpoints:
+      - "POST /submit"
+      - "POST /submit-sync"
+      - "GET  /task/{id}"
+      - "GET  /health"
+    control: "scripts/gatekeeper-ctl.sh"
+
+  firewire:
+    path: "daemon/firewire.py"
+    port: 7801
+    description: "Federation protocol daemon — Ed25519 signing, gossip, peer discovery"
+    control: "scripts/firewire-ctl.sh"
+
+  scheduler:
+    path: "scheduler/scheduler.py"
+    port: 7802
+    description: "Autonomous operation loop — 25 tasks across 6 categories"
+    control: "scripts/scheduler-ctl.sh"
+    categories: [sense, analyze, create, distribute, improve, system]
+
+# =============================================================================
+# CI/CD Pipeline
+# =============================================================================
+
+ci:
+  workflow: ".github/workflows/ci.yml"
+  trigger: "PRs and pushes to main"
+  jobs:
+    - name: lint
+      tools: [shellcheck, yamllint, py_compile]
+    - name: security
+      checks: [secret_patterns, dangerous_files, env_tracking]
+    - name: test
+      script: "scripts/test-plugins.sh"
+    - name: integrity
+      checks: [critical_files, license, principles, manifest_hashes]
+
+  review:
+    workflow: ".github/workflows/claude-review.yml"
+    trigger: "PRs"
+    model: "claude-opus-4-6"

--- a/specs/plugin-registry.yaml
+++ b/specs/plugin-registry.yaml
@@ -1,0 +1,510 @@
+# =============================================================================
+# Plugin Registry — Cleansing Fire
+# =============================================================================
+# Machine-readable catalog of all plugins with capabilities, dependencies,
+# API requirements, and action definitions.
+#
+# For humans: see plugins/README and docs/intelligence-and-osint.md
+# For agents: use this file for plugin discovery and capability matching
+# =============================================================================
+
+metadata:
+  version: "0.1.0"
+  updated: "2026-02-28"
+  description: "Registry of all Cleansing Fire plugins with capabilities, actions, and dependencies"
+  human_docs:
+    - path: "docs/intelligence-and-osint.md"
+      description: "OSINT and exposure infrastructure narrative"
+    - path: "docs/humor-and-satire.md"
+      description: "Satire engine and comedy as weapon"
+
+# =============================================================================
+# Civic Data Plugins — Government transparency
+# =============================================================================
+
+plugins:
+
+  # ---------------------------------------------------------------------------
+  civic-legiscan:
+    category: civic
+    description: "LegiScan legislation tracking — bill search, details, and monitoring"
+    requires_env: [LEGISCAN_API_KEY]
+    uses_gatekeeper: false
+    calls_plugins: []
+    actions:
+      - name: search
+        description: "Search for bills by keyword, state, and session"
+        required_fields: [query]
+        optional_fields: [state, year]
+      - name: bill
+        description: "Get detailed information about a specific bill"
+        required_fields: [bill_id]
+      - name: monitor
+        description: "Track recent bill activity in a state"
+        required_fields: [state]
+
+  # ---------------------------------------------------------------------------
+  civic-fec:
+    category: civic
+    description: "FEC campaign finance data — candidates, donors, contributions"
+    requires_env: []  # Falls back to DEMO_KEY
+    uses_gatekeeper: false
+    calls_plugins: []
+    actions:
+      - name: candidate
+        description: "Search for candidate campaign finance info"
+        required_fields: [name]
+        optional_fields: [state, cycle]
+      - name: donor
+        description: "Search for donor/organization contributions"
+        required_fields: [name]
+        optional_fields: [cycle]
+      - name: contributions
+        description: "Search individual contributions"
+        required_fields: [name]
+        optional_fields: [state, cycle, amount_min]
+      - name: crossref
+        description: "Cross-reference donors across candidates"
+        required_fields: [donor_name]
+
+  # ---------------------------------------------------------------------------
+  civic-spending:
+    category: civic
+    description: "USAspending federal spending data — contracts, grants, agencies"
+    requires_env: []  # No key needed
+    uses_gatekeeper: false
+    calls_plugins: []
+    actions:
+      - name: search
+        description: "Search federal spending by keyword"
+        required_fields: [query]
+        optional_fields: [fiscal_year]
+      - name: recipient
+        description: "Get spending for a specific recipient"
+        required_fields: [name]
+      - name: agency
+        description: "Get spending breakdown by federal agency"
+        required_fields: [agency]
+
+  # ---------------------------------------------------------------------------
+  civic-crossref:
+    category: civic
+    description: "Cross-reference pipeline — chains civic-legiscan, civic-fec, civic-spending"
+    requires_env: []
+    uses_gatekeeper: false
+    calls_plugins: [civic-legiscan, civic-fec, civic-spending]
+    actions:
+      - name: investigate
+        description: "Full cross-reference investigation of an entity"
+        required_fields: [entity]
+        optional_fields: [state]
+      - name: follow_money
+        description: "Trace money flows around an entity"
+        required_fields: [entity]
+      - name: contract_donors
+        description: "Find overlap between government contractors and campaign donors"
+        required_fields: [entity]
+
+# =============================================================================
+# Corporate Intelligence Plugins
+# =============================================================================
+
+  # ---------------------------------------------------------------------------
+  corp-sec:
+    category: osint
+    description: "SEC EDGAR filing analyzer — company search, filings, executive comp, ownership"
+    requires_env: []  # Uses User-Agent header per SEC requirements
+    uses_gatekeeper: false
+    calls_plugins: []
+    actions:
+      - name: search
+        description: "Search for companies in SEC EDGAR"
+        required_fields: [query]
+      - name: filings
+        description: "Get recent filings for a company"
+        required_fields: [cik]
+        optional_fields: [filing_type, count]
+      - name: company
+        description: "Get company details from CIK"
+        required_fields: [cik]
+      - name: executive_comp
+        description: "Extract executive compensation from proxy filings"
+        required_fields: [cik]
+      - name: related_party
+        description: "Find related party transactions"
+        required_fields: [cik]
+      - name: risk_factors
+        description: "Extract risk factor disclosures"
+        required_fields: [cik]
+      - name: insider_transactions
+        description: "Get insider trading (Form 4) data"
+        required_fields: [cik]
+      - name: beneficial_owners
+        description: "Get beneficial ownership from Schedule 13D/G"
+        required_fields: [cik]
+
+  # ---------------------------------------------------------------------------
+  lobby-tracker:
+    category: osint
+    description: "Lobbying disclosure tracker — OpenSecrets API for lobbying, revolving door"
+    requires_env: [OPENSECRETS_API_KEY]
+    uses_gatekeeper: false
+    calls_plugins: []
+    actions:
+      - name: search
+        description: "Search lobbying disclosures"
+        required_fields: [query]
+      - name: registrant
+        description: "Get lobbying firm details"
+        required_fields: [registrant_id]
+      - name: client
+        description: "Get client lobbying activity"
+        required_fields: [client_name]
+      - name: lobbyist
+        description: "Search individual lobbyists"
+        required_fields: [name]
+      - name: issue
+        description: "Search by lobbying issue area"
+        required_fields: [issue_code]
+      - name: bill_lobbying
+        description: "Find lobbying activity on specific bills"
+        required_fields: [bill_id]
+      - name: revolving_door
+        description: "Find revolving door connections"
+        required_fields: [name]
+      - name: top_spenders
+        description: "Get top lobbying spenders"
+        optional_fields: [year, limit]
+      - name: industry
+        description: "Get lobbying by industry sector"
+        required_fields: [industry]
+
+  # ---------------------------------------------------------------------------
+  narrative-detector:
+    category: osint
+    description: "Coordinated narrative and PR campaign detector"
+    requires_env: []
+    uses_gatekeeper: true
+    calls_plugins: []
+    actions:
+      - name: analyze_article
+        description: "Detect PR patterns in a single article"
+        required_fields: [text]
+        optional_fields: [url, source]
+      - name: compare_articles
+        description: "Compare multiple articles for coordinated messaging"
+        required_fields: [articles]
+      - name: detect_campaign
+        description: "Detect if content is part of a PR campaign"
+        required_fields: [text]
+      - name: track_narrative
+        description: "Track a narrative across time"
+        required_fields: [narrative, timeframe]
+      - name: source_analysis
+        description: "Analyze source credibility and bias"
+        required_fields: [source]
+      - name: framing_analysis
+        description: "Analyze framing and rhetorical strategies"
+        required_fields: [text]
+      - name: timeline
+        description: "Build narrative timeline"
+        required_fields: [topic]
+      - name: think_tank_trace
+        description: "Trace think tank influence on narrative"
+        required_fields: [topic]
+
+  # ---------------------------------------------------------------------------
+  osint-social:
+    category: osint
+    description: "Social media OSINT — Reddit, Mastodon, Wikipedia, GitHub, domain, web archive"
+    requires_env: []
+    uses_gatekeeper: false
+    calls_plugins: []
+    actions:
+      - name: reddit_user
+        description: "Analyze Reddit user activity patterns"
+        required_fields: [username]
+      - name: reddit_subreddit
+        description: "Analyze subreddit activity and trends"
+        required_fields: [subreddit]
+      - name: mastodon_user
+        description: "Analyze Mastodon user profile and posts"
+        required_fields: [account_url]
+      - name: mastodon_search
+        description: "Search Mastodon for a topic"
+        required_fields: [query]
+      - name: wikipedia_edits
+        description: "Analyze Wikipedia edit patterns for an article"
+        required_fields: [article]
+      - name: github_org
+        description: "Analyze GitHub organization activity"
+        required_fields: [org]
+      - name: web_archive
+        description: "Search Wayback Machine for historical snapshots"
+        required_fields: [url]
+      - name: domain_info
+        description: "WHOIS and DNS analysis for a domain"
+        required_fields: [domain]
+      - name: coordinated_detection
+        description: "Detect coordinated inauthentic behavior patterns"
+        required_fields: [accounts]
+
+  # ---------------------------------------------------------------------------
+  news-monitor:
+    category: osint
+    description: "News monitoring — RSS feeds, NewsAPI, Mediastack, trending detection"
+    requires_env: []  # NEWSAPI_KEY and MEDIASTACK_KEY optional, falls back to RSS
+    uses_gatekeeper: true
+    calls_plugins: []
+    actions:
+      - name: search
+        description: "Search news across multiple sources"
+        required_fields: [query]
+        optional_fields: [sources, days]
+      - name: monitor
+        description: "Set up monitoring for a topic"
+        required_fields: [query]
+      - name: trending
+        description: "Get trending topics"
+        optional_fields: [category]
+      - name: sources
+        description: "List available news sources"
+
+# =============================================================================
+# Content Generation (Forge) Plugins
+# =============================================================================
+
+  # ---------------------------------------------------------------------------
+  forge-satire:
+    category: forge
+    description: "Satirical content generator — doublespeak, memes, parody, headlines, roasts"
+    requires_env: []
+    uses_gatekeeper: true
+    calls_plugins: []
+    actions:
+      - name: satirize
+        description: "Translate corporate/government text into doublespeak"
+        required_fields: [text]
+      - name: meme-text
+        description: "Generate meme-style captions from data"
+        required_fields: [topic]
+      - name: parody
+        description: "Generate parody press release, memo, or FAQ"
+        required_fields: [type, subject]
+      - name: headline
+        description: "Generate satirical headlines (Onion/Borowitz style)"
+        required_fields: [topic]
+      - name: roast
+        description: "Data-driven satirical roast"
+        required_fields: [entity]
+      - name: help
+        description: "List available actions"
+
+  # ---------------------------------------------------------------------------
+  forge-vision:
+    category: forge
+    description: "Visual content generator — SVG diagrams, ASCII art, Mermaid, image prompts"
+    requires_env: []
+    uses_gatekeeper: true
+    calls_plugins: []
+    actions:
+      - name: money_flow
+        description: "Generate money flow SVG diagram"
+        required_fields: [flows]
+      - name: corruption_meter
+        description: "Generate corruption risk meter SVG"
+        required_fields: [entity, score]
+      - name: timeline
+        description: "Generate event timeline SVG"
+        required_fields: [events]
+      - name: ascii_fire
+        description: "Generate ASCII art fire animation"
+        optional_fields: [intensity]
+      - name: mermaid
+        description: "Generate Mermaid diagram from data"
+        required_fields: [type, data]
+      - name: prompt
+        description: "Generate image generation prompts"
+        required_fields: [concept]
+
+  # ---------------------------------------------------------------------------
+  forge-voice:
+    category: forge
+    description: "Text content generator — social posts, threads, digests, poetry, agitprop"
+    requires_env: []
+    uses_gatekeeper: true
+    calls_plugins: []
+    actions:
+      - name: social
+        description: "Generate social media post"
+        required_fields: [data]
+        optional_fields: [platform, tone]
+      - name: thread
+        description: "Generate multi-post thread"
+        required_fields: [data]
+      - name: digest
+        description: "Generate newsletter/digest from data"
+        required_fields: [items]
+      - name: poeticize
+        description: "Transform data into poetry"
+        required_fields: [data]
+      - name: agitprop
+        description: "Generate agitational propaganda"
+        required_fields: [issue]
+
+# =============================================================================
+# Distribution Plugins
+# =============================================================================
+
+  # ---------------------------------------------------------------------------
+  social-bluesky:
+    category: distribution
+    description: "Bluesky AT Protocol bridge — post, thread, profile, timeline, search"
+    requires_env: [BLUESKY_HANDLE, BLUESKY_APP_PASSWORD]
+    uses_gatekeeper: false
+    calls_plugins: []
+    actions:
+      - name: post
+        description: "Post to Bluesky"
+        required_fields: [text]
+      - name: thread
+        description: "Post a thread to Bluesky"
+        required_fields: [posts]
+      - name: profile
+        description: "Get a Bluesky profile"
+        required_fields: [handle]
+      - name: timeline
+        description: "Get the authenticated user's timeline"
+      - name: search
+        description: "Search Bluesky posts"
+        required_fields: [query]
+
+  # ---------------------------------------------------------------------------
+  social-mastodon:
+    category: distribution
+    description: "Mastodon bridge — post, thread, timeline, search, trending"
+    requires_env: [MASTODON_INSTANCE, MASTODON_ACCESS_TOKEN]
+    uses_gatekeeper: false
+    calls_plugins: []
+    actions:
+      - name: post
+        description: "Post to Mastodon"
+        required_fields: [text]
+      - name: thread
+        description: "Post a thread to Mastodon"
+        required_fields: [posts]
+      - name: timeline
+        description: "Get the home timeline"
+      - name: search
+        description: "Search Mastodon"
+        required_fields: [query]
+      - name: trending
+        description: "Get trending hashtags and posts"
+
+# =============================================================================
+# Legal & Security Plugins
+# =============================================================================
+
+  # ---------------------------------------------------------------------------
+  legal-automation:
+    category: legal
+    description: "Legal document generator — FOIA, regulatory complaints, rights cards, public comments"
+    requires_env: []
+    uses_gatekeeper: true
+    calls_plugins: []
+    actions:
+      - name: foia-generate
+        description: "Generate a FOIA request letter"
+        required_fields: [agency, topic]
+        optional_fields: [state, details]
+      - name: complaint-draft
+        description: "Draft a regulatory complaint (FTC/FCC/SEC/EPA/CFPB)"
+        required_fields: [agency, subject]
+      - name: rights-card
+        description: "Generate a know-your-rights card"
+        required_fields: [scenario]
+      - name: cease-desist-respond
+        description: "Draft a response to a cease-and-desist letter"
+        required_fields: [letter_text]
+      - name: public-comment
+        description: "Draft a public comment for rulemaking"
+        required_fields: [docket, position]
+
+  # ---------------------------------------------------------------------------
+  whistleblower-submit:
+    category: security
+    description: "Secure tip submission — encryption, Tor verification, local/remote submission"
+    requires_env: []  # TOR_SOCKS_PROXY optional
+    uses_gatekeeper: false
+    calls_plugins: []
+    actions:
+      - name: generate_keypair
+        description: "Generate Ed25519 keypair for tip encryption"
+      - name: encrypt_tip
+        description: "Encrypt a tip for secure submission"
+        required_fields: [tip_text, recipient_pubkey]
+      - name: submit_local
+        description: "Submit encrypted tip to local storage"
+        required_fields: [encrypted_tip]
+      - name: submit_remote
+        description: "Submit encrypted tip via Tor (if available)"
+        required_fields: [encrypted_tip, endpoint]
+      - name: list_tips
+        description: "List received tips (requires private key)"
+      - name: decrypt_tip
+        description: "Decrypt a received tip"
+        required_fields: [encrypted_tip, private_key]
+      - name: verify_tor
+        description: "Verify Tor connectivity"
+      - name: security_check
+        description: "Run security environment checks"
+
+# =============================================================================
+# Pipeline & Federation Plugins
+# =============================================================================
+
+  # ---------------------------------------------------------------------------
+  pipeline-data-to-fire:
+    category: pipeline
+    description: "Full pipeline: data → analysis → visualization → narrative → distribution"
+    requires_env: []
+    uses_gatekeeper: true
+    calls_plugins: [civic-legiscan, civic-fec, civic-spending, forge-vision, forge-voice]
+    actions:
+      - name: full_investigation
+        description: "Run full investigation pipeline on an entity"
+        required_fields: [entity]
+        optional_fields: [state]
+      - name: bill_spotlight
+        description: "Spotlight a specific bill with full analysis"
+        required_fields: [bill_id]
+      - name: weekly_fire
+        description: "Generate weekly digest from recent data"
+
+  # ---------------------------------------------------------------------------
+  firewire-relay:
+    category: federation
+    description: "FireWire protocol relay — message relay, peer discovery, network operations"
+    requires_env: []  # FIREWIRE_URL optional, defaults to localhost:7801
+    uses_gatekeeper: false
+    calls_plugins: []
+    actions:
+      - name: relay
+        description: "Relay a signed message to the network"
+        required_fields: [message]
+      - name: peers
+        description: "List known peers"
+      - name: announce
+        description: "Announce this node's presence"
+
+  # ---------------------------------------------------------------------------
+  example-summarize:
+    category: example
+    description: "Example/template plugin — demonstrates the plugin contract"
+    requires_env: []
+    uses_gatekeeper: true
+    calls_plugins: []
+    actions:
+      - name: summarize
+        description: "Summarize input text using the gatekeeper LLM"
+        required_fields: [text]


### PR DESCRIPTION
## Summary

Expands the `specs/` directory with three machine-readable specification files for AI agents and dual documentation.

### Changes
- **`specs/plugin-registry.yaml`** — catalog of all 19 plugins with:
  - All actions with required/optional fields
  - Required environment variables
  - Gatekeeper usage flags
  - Inter-plugin dependencies
- **`specs/deployment-spec.yaml`** — deployment targets:
  - GitHub Pages configuration
  - 4 Cloudflare Workers with all bindings (KV, D1, R2, Queues, Services)
  - 3 local daemons (gatekeeper, firewire, scheduler)
  - CI/CD pipeline structure
- **`specs/data-model.yaml`** — D1 database schema:
  - `civic-data` database: 7 tables (entities, relationships, investigations, documents, tips, foia_requests, content)
  - `fire-relay` database: 2 tables (relay_events, registered_nodes)
  - All with columns, types, constraints, and indexes
- Updated `specs/README.md` file index

### Refs
Closes #96